### PR TITLE
Add modern styling with Tailwind

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # Divnex
+
+Divnex es una WebApp local para gestión de proyectos inspirada en ClickUp y Monday. Todo corre directamente en el navegador sin necesidad de backend ni bases de datos externas.
+
+## Uso
+
+1. Clona este repositorio o descarga los archivos.
+2. Abre `index.html` en tu navegador preferido.
+3. La aplicación guardará los datos en `localStorage` de forma automática.
+4. Puedes exportar o importar un archivo JSON como respaldo.
+
+## Estructura
+
+- `index.html` – Entrada principal de la aplicación.
+- `divnex.js` – Lógica y modelos de datos.
+- `components/` – Componentes reutilizables como columnas Kanban y tarjetas.
+- `styles/` – Estilos básicos.
+- `templates/` – Plantillas de proyectos y tareas.
+
+La aplicación incluye datos de ejemplo la primera vez que se abre para mostrar el funcionamiento básico.

--- a/components/kanban.js
+++ b/components/kanban.js
@@ -1,0 +1,31 @@
+export function statusColor(status) {
+  switch (status) {
+    case 'In Progress':
+      return '#fbbf24';
+    case 'Done':
+      return '#10b981';
+    default:
+      return '#94a3b8';
+  }
+}
+
+export function createKanbanColumn(title) {
+  const column = document.createElement('div');
+  column.className = 'bg-gray-100 rounded-lg p-4 flex-1 mr-4 last:mr-0';
+  const header = document.createElement('h3');
+  header.className = 'font-semibold mb-2';
+  header.textContent = title;
+  column.appendChild(header);
+  const list = document.createElement('div');
+  list.className = 'space-y-2 min-h-[100px]';
+  column.appendChild(list);
+  return { column, list };
+}
+
+export function createTaskCard(task) {
+  const card = document.createElement('div');
+  card.className = 'bg-white rounded-lg shadow p-3 text-sm';
+  card.style.borderLeft = `4px solid ${statusColor(task.status)}`;
+  card.textContent = task.title;
+  return card;
+}

--- a/components/task.js
+++ b/components/task.js
@@ -1,0 +1,15 @@
+import { statusColor } from './kanban.js';
+
+export function createTaskRow(task) {
+  const row = document.createElement('div');
+  row.className = 'bg-white rounded-md shadow p-3 mb-2 flex justify-between items-center text-sm';
+  row.style.borderLeft = `4px solid ${statusColor(task.status)}`;
+  const title = document.createElement('span');
+  title.textContent = task.title;
+  const status = document.createElement('span');
+  status.className = 'text-gray-500';
+  status.textContent = task.status;
+  row.appendChild(title);
+  row.appendChild(status);
+  return row;
+}

--- a/divnex.js
+++ b/divnex.js
@@ -1,0 +1,144 @@
+import { createKanbanColumn, createTaskCard } from "./components/kanban.js";
+import { createTaskRow } from "./components/task.js";
+class Task {
+  constructor({ id, title, description = '', status = 'To Do', priority = 'Media', type = 'General', estimate = 1 }) {
+    this.id = id || Date.now();
+    this.title = title;
+    this.description = description;
+    this.status = status;
+    this.priority = priority;
+    this.type = type;
+    this.estimate = estimate;
+  }
+  toJSON() {
+    return { id: this.id, title: this.title, description: this.description, status: this.status, priority: this.priority, type: this.type, estimate: this.estimate };
+  }
+  static fromJSON(obj) {
+    return new Task(obj);
+  }
+}
+
+class Project {
+  constructor({ id, name, tasks = [] }) {
+    this.id = id || Date.now();
+    this.name = name;
+    this.tasks = tasks.map(t => Task.fromJSON(t));
+  }
+  toJSON() {
+    return { id: this.id, name: this.name, tasks: this.tasks.map(t => t.toJSON()) };
+  }
+  static fromJSON(obj) {
+    return new Project(obj);
+  }
+}
+
+const App = {
+  data: { projects: [] },
+  currentView: 'list',
+  load() {
+    const saved = localStorage.getItem('divnexData');
+    if (saved) {
+      const parsed = JSON.parse(saved);
+      this.data.projects = parsed.projects.map(p => Project.fromJSON(p));
+    } else {
+      this.data.projects = [
+        new Project({
+          name: 'Proyecto Demo',
+          tasks: [
+            new Task({ title: 'Tarea de ejemplo', status: 'To Do' }),
+            new Task({ title: 'Otra tarea', status: 'In Progress' })
+          ]
+        })
+      ];
+      this.save();
+    }
+  },
+  save() {
+    localStorage.setItem('divnexData', JSON.stringify({ projects: this.data.projects.map(p => p.toJSON()) }));
+  },
+  renderProjectList() {
+    const list = document.getElementById('projectList');
+    list.innerHTML = '';
+    this.data.projects.forEach(p => {
+      const li = document.createElement('li');
+      li.className = 'cursor-pointer px-2 py-1 rounded hover:bg-gray-100';
+      li.textContent = p.name;
+      li.onclick = () => { this.currentProject = p; this.renderView(); };
+      list.appendChild(li);
+    });
+  },
+  renderView() {
+    const main = document.getElementById('mainView');
+    main.innerHTML = '';
+    if (!this.currentProject) return;
+    if (this.currentView === 'kanban') {
+      this.renderKanban(main, this.currentProject);
+    } else if (this.currentView === 'list') {
+      this.renderList(main, this.currentProject);
+    } else {
+      main.textContent = 'Vista calendario no implementada';
+    }
+  },
+  renderList(container, project) {
+    project.tasks.forEach(task => {
+      container.appendChild(createTaskRow(task));
+    });
+  },
+  renderKanban(container, project) {
+    const board = document.createElement('div');
+    board.className = 'flex gap-4';
+    const statuses = ['To Do', 'In Progress', 'Done'];
+    statuses.forEach(status => {
+      const { column, list } = createKanbanColumn(status);
+      project.tasks.filter(t => t.status === status).forEach(t => {
+        list.appendChild(createTaskCard(t));
+      });
+      board.appendChild(column);
+    });
+    container.appendChild(board);
+  },
+  addProject() {
+    const name = prompt('Nombre del proyecto');
+    if (!name) return;
+    const project = new Project({ name });
+    this.data.projects.push(project);
+    this.save();
+    this.renderProjectList();
+  },
+  exportJSON() {
+    const dataStr = JSON.stringify({ projects: this.data.projects.map(p => p.toJSON()) }, null, 2);
+    const blob = new Blob([dataStr], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'divnex-data.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  },
+  importJSON(file) {
+    const reader = new FileReader();
+    reader.onload = e => {
+      const parsed = JSON.parse(e.target.result);
+      this.data.projects = parsed.projects.map(p => Project.fromJSON(p));
+      this.save();
+      this.renderProjectList();
+      this.renderView();
+    };
+    reader.readAsText(file);
+  }
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  App.load();
+  App.renderProjectList();
+  document.getElementById('addProjectBtn').onclick = () => App.addProject();
+  document.querySelectorAll('.view-btn').forEach(btn => {
+    btn.onclick = () => { App.currentView = btn.dataset.view; App.renderView(); };
+  });
+  document.getElementById('exportBtn').onclick = () => App.exportJSON();
+  document.getElementById('importBtn').onclick = () => document.getElementById('importFile').click();
+  document.getElementById('importFile').onchange = e => {
+    const file = e.target.files[0];
+    if (file) App.importJSON(file);
+  };
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Divnex</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: { inter: ['Inter', 'sans-serif'] }
+        }
+      }
+    };
+  </script>
+  <link rel="stylesheet" href="styles/main.css">
+</head>
+<body class="font-inter bg-gray-50 h-screen flex flex-col">
+  <header class="bg-gradient-to-r from-indigo-500 to-blue-500 text-white p-4 flex justify-between items-center">
+    <h1 class="text-xl font-semibold">Divnex</h1>
+    <nav class="space-x-2">
+      <button data-view="list" class="view-btn px-3 py-1 rounded-md hover:bg-white/20">Lista</button>
+      <button data-view="kanban" class="view-btn px-3 py-1 rounded-md hover:bg-white/20">Kanban</button>
+      <button data-view="calendar" class="view-btn px-3 py-1 rounded-md hover:bg-white/20">Calendario</button>
+      <button id="exportBtn" class="ml-3 px-3 py-1 rounded-md bg-white/20 hover:bg-white/30">Exportar</button>
+      <button id="importBtn" class="px-3 py-1 rounded-md bg-white/20 hover:bg-white/30">Importar</button>
+      <input type="file" id="importFile" class="hidden" />
+    </nav>
+  </header>
+  <div id="container" class="flex flex-1 overflow-hidden">
+    <aside id="sidebar" class="w-64 bg-white border-r p-4 overflow-y-auto">
+      <div class="flex items-center justify-between mb-4">
+        <h2 class="text-lg font-semibold">Proyectos</h2>
+        <button id="addProjectBtn" class="text-indigo-600 hover:text-indigo-800">+</button>
+      </div>
+      <ul id="projectList" class="space-y-2"></ul>
+    </aside>
+    <main id="mainView" class="flex-1 p-4 overflow-y-auto"></main>
+  </div>
+  <script type="module" src="divnex.js"></script>
+</body>
+</html>

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,0 +1,5 @@
+body {
+  margin: 0;
+  font-family: 'Inter', sans-serif;
+  background: #f9fafb;
+}

--- a/templates/projectTemplate.json
+++ b/templates/projectTemplate.json
@@ -1,0 +1,4 @@
+{
+  "name": "Nuevo Proyecto",
+  "tasks": []
+}

--- a/templates/taskTemplate.json
+++ b/templates/taskTemplate.json
@@ -1,0 +1,8 @@
+{
+  "title": "Nueva Tarea",
+  "description": "Descripcion",
+  "status": "To Do",
+  "priority": "Media",
+  "type": "General",
+  "estimate": 1
+}


### PR DESCRIPTION
## Summary
- integrate Tailwind CDN and Inter font
- redesign layout for navbar and sidebar
- style Kanban columns and task cards
- style list view rows and project list items
- clean up custom CSS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851f6cb6a8c832594648dd9950550ae