### PR TITLE
Enable drag and drop for tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # Divnex
+
+Divnex es una WebApp local para gestión de proyectos inspirada en ClickUp y Monday. Todo corre directamente en el navegador sin necesidad de backend ni bases de datos externas.
+
+## Uso
+
+1. Clona este repositorio o descarga los archivos.
+2. Abre `index.html` en tu navegador preferido.
+3. La aplicación guardará los datos en `localStorage` de forma automática.
+4. Puedes exportar o importar un archivo JSON como respaldo.
+
+## Estructura
+
+- `index.html` – Entrada principal de la aplicación.
+- `divnex.js` – Lógica y modelos de datos.
+- `components/` – Componentes reutilizables como columnas Kanban y tarjetas.
+- `styles/` – Estilos básicos.
+- `templates/` – Plantillas de proyectos y tareas.
+
+La aplicación incluye datos de ejemplo la primera vez que se abre para mostrar el funcionamiento básico.

--- a/components/kanban.js
+++ b/components/kanban.js
@@ -1,0 +1,45 @@
+export function statusColor(status) {
+  switch (status) {
+    case 'In Progress':
+      return '#fbbf24';
+    case 'Done':
+      return '#10b981';
+    default:
+      return '#94a3b8';
+  }
+}
+
+export function createKanbanColumn(title) {
+  const column = document.createElement('div');
+  column.className = 'bg-gray-100 rounded-lg p-4 flex-1 mr-4 last:mr-0';
+  const header = document.createElement('h3');
+  header.className = 'font-semibold mb-2';
+  header.textContent = title;
+  column.appendChild(header);
+  const list = document.createElement('div');
+  list.className = 'space-y-2 min-h-[100px]';
+  column.appendChild(list);
+  return { column, list };
+}
+
+export function createTaskCard(task, handlers = {}) {
+  const card = document.createElement('div');
+  card.className = 'bg-white rounded-lg shadow p-3 text-sm cursor-pointer';
+  card.draggable = true;
+  card.dataset.id = task.id;
+  card.style.borderLeft = `4px solid ${task.color || statusColor(task.status)}`;
+  const title = document.createElement('div');
+  title.textContent = task.title;
+  card.appendChild(title);
+  if (task.subtasks && task.subtasks.length) {
+    const progress = document.createElement('div');
+    const done = task.subtasks.filter(s => s.done).length;
+    progress.className = 'text-xs text-gray-500';
+    progress.textContent = `${done}/${task.subtasks.length}`;
+    card.appendChild(progress);
+  }
+  if (handlers.onClick) card.addEventListener('click', e => handlers.onClick(e, task));
+  if (handlers.onContext) card.addEventListener('contextmenu', e => handlers.onContext(e, task));
+  if (handlers.onDragStart) card.addEventListener('dragstart', e => handlers.onDragStart(e, task));
+  return card;
+}

--- a/components/task.js
+++ b/components/task.js
@@ -1,0 +1,27 @@
+import { statusColor } from './kanban.js';
+
+export function createTaskRow(task, handlers = {}) {
+  const row = document.createElement('div');
+  row.className = 'bg-white rounded-md shadow p-3 mb-2 flex justify-between items-center text-sm cursor-pointer';
+  row.draggable = true;
+  row.dataset.id = task.id;
+  row.style.borderLeft = `4px solid ${task.color || statusColor(task.status)}`;
+  const title = document.createElement('span');
+  let text = task.title;
+  if (task.subtasks && task.subtasks.length) {
+    const done = task.subtasks.filter(s => s.done).length;
+    text += ` (${done}/${task.subtasks.length})`;
+  }
+  title.textContent = text;
+  const status = document.createElement('span');
+  status.className = 'text-gray-500';
+  status.textContent = task.status;
+  row.appendChild(title);
+  row.appendChild(status);
+  if (handlers.onClick) row.addEventListener('click', e => handlers.onClick(e, task));
+  if (handlers.onContext) row.addEventListener('contextmenu', e => handlers.onContext(e, task));
+  if (handlers.onDragStart) row.addEventListener('dragstart', e => handlers.onDragStart(e, task));
+  if (handlers.onDrop) row.addEventListener('drop', e => handlers.onDrop(e, task));
+  if (handlers.onDragOver) row.addEventListener('dragover', e => handlers.onDragOver(e, task));
+  return row;
+}

--- a/divnex.js
+++ b/divnex.js
@@ -1,0 +1,321 @@
+import { createKanbanColumn, createTaskCard } from "./components/kanban.js";
+import { createTaskRow } from "./components/task.js";
+class Task {
+  constructor({ id, title, description = '', status = 'To Do', priority = 'Media', type = 'General', estimate = 1, color = '', subtasks = [] }) {
+    this.id = id || Date.now();
+    this.title = title;
+    this.description = description;
+    this.status = status;
+    this.priority = priority;
+    this.type = type;
+    this.estimate = estimate;
+    this.color = color;
+    this.subtasks = subtasks.map(s => ({ id: s.id || Date.now(), title: s.title, done: !!s.done }));
+  }
+  toJSON() {
+    return {
+      id: this.id,
+      title: this.title,
+      description: this.description,
+      status: this.status,
+      priority: this.priority,
+      type: this.type,
+      estimate: this.estimate,
+      color: this.color,
+      subtasks: this.subtasks
+    };
+  }
+  static fromJSON(obj) {
+    return new Task(obj);
+  }
+}
+
+class Project {
+  constructor({ id, name, tasks = [] }) {
+    this.id = id || Date.now();
+    this.name = name;
+    this.tasks = tasks.map(t => Task.fromJSON(t));
+  }
+  toJSON() {
+    return { id: this.id, name: this.name, tasks: this.tasks.map(t => t.toJSON()) };
+  }
+  static fromJSON(obj) {
+    return new Project(obj);
+  }
+}
+
+const App = {
+  data: { projects: [] },
+  currentView: 'list',
+  currentProject: null,
+  contextTask: null,
+  modalTask: null,
+  modalSubtasks: [],
+  draggedTask: null,
+  load() {
+    const saved = localStorage.getItem('divnexData');
+    if (saved) {
+      const parsed = JSON.parse(saved);
+      this.data.projects = parsed.projects.map(p => Project.fromJSON(p));
+    } else {
+      this.data.projects = [
+        new Project({
+          name: 'Proyecto Demo',
+          tasks: [
+            new Task({ title: 'Tarea de ejemplo', status: 'To Do' }),
+            new Task({ title: 'Otra tarea', status: 'In Progress' })
+          ]
+        })
+      ];
+      this.save();
+    }
+    if (this.data.projects.length) this.currentProject = this.data.projects[0];
+  },
+  save() {
+    localStorage.setItem('divnexData', JSON.stringify({ projects: this.data.projects.map(p => p.toJSON()) }));
+  },
+  renderProjectList() {
+    const list = document.getElementById('projectList');
+    list.innerHTML = '';
+    this.data.projects.forEach(p => {
+      const li = document.createElement('li');
+      li.className = 'cursor-pointer px-2 py-1 rounded hover:bg-gray-100';
+      li.textContent = p.name;
+      li.onclick = () => { this.currentProject = p; this.renderView(); };
+      list.appendChild(li);
+    });
+  },
+  renderView() {
+    const main = document.getElementById('mainView');
+    main.innerHTML = '';
+    if (!this.currentProject) return;
+    if (this.currentView === 'kanban') {
+      this.renderKanban(main, this.currentProject);
+    } else if (this.currentView === 'list') {
+      this.renderList(main, this.currentProject);
+    } else {
+      main.textContent = 'Vista calendario no implementada';
+    }
+  },
+  renderList(container, project) {
+    project.tasks.forEach(task => {
+      container.appendChild(createTaskRow(task, {
+        onClick: (_e, t) => this.editTask(t),
+        onContext: (e, t) => this.showContextMenu(e, t),
+        onDragStart: (_e, t) => this.startDrag(t),
+        onDragOver: e => e.preventDefault(),
+        onDrop: (_e, t) => {
+          const idx = project.tasks.findIndex(x => x.id === t.id);
+          this.dropList(idx);
+        }
+      }));
+    });
+    container.ondragover = e => e.preventDefault();
+    container.ondrop = e => {
+      if (e.target === container) this.dropList(-1);
+    };
+  },
+  renderKanban(container, project) {
+    const board = document.createElement('div');
+    board.className = 'flex gap-4';
+    const statuses = ['To Do', 'In Progress', 'Done'];
+    statuses.forEach(status => {
+      const { column, list } = createKanbanColumn(status);
+      list.ondragover = e => e.preventDefault();
+      list.ondrop = () => this.dropKanban(status);
+      project.tasks.filter(t => t.status === status).forEach(t => {
+        list.appendChild(createTaskCard(t, {
+          onClick: (_e, task) => this.editTask(task),
+          onContext: (e, task) => this.showContextMenu(e, task),
+          onDragStart: (_e, task) => this.startDrag(task)
+        }));
+      });
+      board.appendChild(column);
+    });
+    container.appendChild(board);
+  },
+  editTask(task) {
+    this.showTaskModal(task);
+  },
+  addTask() {
+    this.showTaskModal(null);
+  },
+  showTaskModal(task) {
+    this.modalTask = task;
+    document.getElementById('taskModalTitle').textContent = task ? 'Editar Tarea' : 'Nueva Tarea';
+    document.getElementById('taskTitle').value = task ? task.title : '';
+    document.getElementById('taskStatus').value = task ? task.status : 'To Do';
+    document.getElementById('taskColor').value = task && task.color ? task.color : '#94a3b8';
+    this.modalSubtasks = task ? task.subtasks.map(s => ({ ...s })) : [];
+    this.renderSubtasks();
+    document.getElementById('taskModal').classList.remove('hidden');
+  },
+  closeTaskModal() {
+    document.getElementById('taskModal').classList.add('hidden');
+    this.modalTask = null;
+  },
+  renderSubtasks() {
+    const list = document.getElementById('subtaskList');
+    list.innerHTML = '';
+    this.modalSubtasks.forEach((s, idx) => {
+      const li = document.createElement('li');
+      li.className = 'flex items-center';
+      const cb = document.createElement('input');
+      cb.type = 'checkbox';
+      cb.checked = s.done;
+      cb.onchange = () => { s.done = cb.checked; };
+      const span = document.createElement('span');
+      span.className = 'flex-1 ml-2';
+      span.textContent = s.title;
+      const del = document.createElement('button');
+      del.textContent = '✕';
+      del.className = 'text-red-500 ml-2';
+      del.onclick = () => { this.modalSubtasks.splice(idx, 1); this.renderSubtasks(); };
+      li.appendChild(cb);
+      li.appendChild(span);
+      li.appendChild(del);
+      list.appendChild(li);
+    });
+  },
+  saveTaskFromModal() {
+    const title = document.getElementById('taskTitle').value.trim();
+    if (!title) return;
+    const status = document.getElementById('taskStatus').value;
+    const color = document.getElementById('taskColor').value;
+    if (this.modalTask) {
+      this.modalTask.title = title;
+      this.modalTask.status = status;
+      this.modalTask.color = color;
+      this.modalTask.subtasks = this.modalSubtasks;
+    } else {
+      const task = new Task({ title, status, color, subtasks: this.modalSubtasks });
+      this.currentProject.tasks.push(task);
+    }
+    this.save();
+    this.renderView();
+    this.closeTaskModal();
+  },
+  showContextMenu(e, task) {
+    e.preventDefault();
+    this.contextTask = task;
+    const menu = document.getElementById('contextMenu');
+    menu.style.left = `${e.pageX}px`;
+    menu.style.top = `${e.pageY}px`;
+    menu.classList.remove('hidden');
+  },
+  hideContextMenu() {
+    document.getElementById('contextMenu').classList.add('hidden');
+  },
+  deleteTask() {
+    if (!this.contextTask || !this.currentProject) return;
+    this.currentProject.tasks = this.currentProject.tasks.filter(t => t !== this.contextTask);
+    this.contextTask = null;
+    this.save();
+    this.renderView();
+    this.hideContextMenu();
+  },
+  addProject() {
+    const name = prompt('Nombre del proyecto');
+    if (!name) return;
+    const project = new Project({ name });
+    this.data.projects.push(project);
+    this.save();
+    this.renderProjectList();
+  },
+  exportJSON() {
+    const dataStr = JSON.stringify({ projects: this.data.projects.map(p => p.toJSON()) }, null, 2);
+    const blob = new Blob([dataStr], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'divnex-data.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  },
+  importJSON(file) {
+    const reader = new FileReader();
+    reader.onload = e => {
+      const parsed = JSON.parse(e.target.result);
+      this.data.projects = parsed.projects.map(p => Project.fromJSON(p));
+      this.save();
+      this.renderProjectList();
+      this.renderView();
+    };
+    reader.readAsText(file);
+  },
+  startDrag(task) {
+    this.draggedTask = task;
+  },
+  dropKanban(status) {
+    if (!this.draggedTask || !this.currentProject) return;
+    const idx = this.currentProject.tasks.findIndex(t => t.id === this.draggedTask.id);
+    if (idx !== -1) {
+      this.currentProject.tasks[idx].status = status;
+      const [t] = this.currentProject.tasks.splice(idx, 1);
+      this.currentProject.tasks.push(t);
+      this.save();
+      this.renderView();
+    }
+    this.draggedTask = null;
+  },
+  dropList(index) {
+    if (!this.draggedTask || !this.currentProject) return;
+    const arr = this.currentProject.tasks;
+    const from = arr.findIndex(t => t.id === this.draggedTask.id);
+    if (from === -1) return;
+    const [task] = arr.splice(from, 1);
+    if (index < 0 || index >= arr.length) {
+      arr.push(task);
+    } else {
+      if (from < index) index--;
+      arr.splice(index, 0, task);
+    }
+    this.save();
+    this.renderView();
+    this.draggedTask = null;
+  }
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  App.load();
+  App.renderProjectList();
+  document.getElementById('addProjectBtn').onclick = () => App.addProject();
+  document.querySelectorAll('.view-btn').forEach(btn => {
+    btn.onclick = () => { App.currentView = btn.dataset.view; App.renderView(); };
+  });
+  document.getElementById('exportBtn').onclick = () => App.exportJSON();
+  document.getElementById('importBtn').onclick = () => document.getElementById('importFile').click();
+  document.getElementById('importFile').onchange = e => {
+    const file = e.target.files[0];
+    if (file) App.importJSON(file);
+  };
+  document.getElementById('addTaskBtn').onclick = () => App.addTask();
+  document.getElementById('cancelTaskBtn').onclick = () => App.closeTaskModal();
+  document.getElementById('saveTaskBtn').onclick = () => App.saveTaskFromModal();
+  document.getElementById('addSubtaskBtn').onclick = () => {
+    const input = document.getElementById('subtaskInput');
+    const title = input.value.trim();
+    if (title) {
+      App.modalSubtasks.push({ id: Date.now(), title, done: false });
+      input.value = '';
+      App.renderSubtasks();
+    }
+  };
+  document.getElementById('taskModal').addEventListener('click', e => {
+    if (e.target.id === 'taskModal') App.closeTaskModal();
+  });
+  document.getElementById('editTask').onclick = () => {
+    if (App.contextTask) App.editTask(App.contextTask);
+    App.hideContextMenu();
+  };
+  document.getElementById('deleteTask').onclick = () => App.deleteTask();
+  document.addEventListener('click', e => {
+    const menu = document.getElementById('contextMenu');
+    if (!menu.contains(e.target)) App.hideContextMenu();
+  });
+  document.addEventListener('contextmenu', e => {
+    const menu = document.getElementById('contextMenu');
+    if (!menu.contains(e.target)) App.hideContextMenu();
+  });
+  document.addEventListener('dragend', () => { App.draggedTask = null; });
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Divnex</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: { inter: ['Inter', 'sans-serif'] }
+        }
+      }
+    };
+  </script>
+  <link rel="stylesheet" href="styles/main.css">
+</head>
+<body class="font-inter bg-gray-50 h-screen flex flex-col">
+  <header class="bg-gradient-to-r from-indigo-500 to-blue-500 text-white p-4 flex justify-between items-center">
+    <h1 class="text-xl font-semibold">Divnex</h1>
+    <nav class="space-x-2">
+      <button data-view="list" class="view-btn px-3 py-1 rounded-md hover:bg-white/20">Lista</button>
+      <button data-view="kanban" class="view-btn px-3 py-1 rounded-md hover:bg-white/20">Kanban</button>
+      <button data-view="calendar" class="view-btn px-3 py-1 rounded-md hover:bg-white/20">Calendario</button>
+      <button id="exportBtn" class="ml-3 px-3 py-1 rounded-md bg-white/20 hover:bg-white/30">Exportar</button>
+      <button id="importBtn" class="px-3 py-1 rounded-md bg-white/20 hover:bg-white/30">Importar</button>
+      <button id="addTaskBtn" class="ml-3 px-3 py-1 rounded-md bg-white/20 hover:bg-white/30">Nueva Tarea</button>
+      <input type="file" id="importFile" class="hidden" />
+    </nav>
+  </header>
+  <div id="container" class="flex flex-1 overflow-hidden">
+    <aside id="sidebar" class="w-64 bg-white border-r p-4 overflow-y-auto">
+      <div class="flex items-center justify-between mb-4">
+        <h2 class="text-lg font-semibold">Proyectos</h2>
+        <button id="addProjectBtn" class="text-indigo-600 hover:text-indigo-800">+</button>
+      </div>
+      <ul id="projectList" class="space-y-2"></ul>
+    </aside>
+    <main id="mainView" class="flex-1 p-4 overflow-y-auto"></main>
+  </div>
+  <div id="contextMenu" class="absolute bg-white rounded-md shadow text-sm py-1 hidden z-50">
+    <button id="editTask" class="block w-full text-left px-4 py-1 hover:bg-gray-100">Editar</button>
+    <button id="deleteTask" class="block w-full text-left px-4 py-1 hover:bg-gray-100">Eliminar</button>
+  </div>
+  <div id="taskModal" class="fixed inset-0 bg-black/50 flex items-center justify-center hidden z-50">
+    <div class="bg-white rounded-lg p-4 w-80 space-y-2">
+      <h3 id="taskModalTitle" class="text-lg font-semibold">Nueva Tarea</h3>
+      <input id="taskTitle" type="text" class="w-full border rounded p-2" placeholder="Título" />
+      <select id="taskStatus" class="w-full border rounded p-2">
+        <option value="To Do">To Do</option>
+        <option value="In Progress">In Progress</option>
+        <option value="Done">Done</option>
+      </select>
+      <label class="block text-sm">Color
+        <input id="taskColor" type="color" class="ml-2" />
+      </label>
+      <div>
+        <div class="flex mb-1">
+          <input id="subtaskInput" type="text" class="flex-1 border rounded-l p-2" placeholder="Subtarea" />
+          <button id="addSubtaskBtn" class="border rounded-r px-2 bg-gray-100">+</button>
+        </div>
+        <ul id="subtaskList" class="space-y-1 max-h-32 overflow-y-auto"></ul>
+      </div>
+      <div class="flex justify-end space-x-2 pt-2">
+        <button id="cancelTaskBtn" class="px-3 py-1 rounded bg-gray-200">Cancelar</button>
+        <button id="saveTaskBtn" class="px-3 py-1 rounded bg-indigo-500 text-white">Guardar</button>
+      </div>
+    </div>
+  </div>
+  <script type="module" src="divnex.js"></script>
+</body>
+</html>

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,0 +1,5 @@
+body {
+  margin: 0;
+  font-family: 'Inter', sans-serif;
+  background: #f9fafb;
+}

--- a/templates/projectTemplate.json
+++ b/templates/projectTemplate.json
@@ -1,0 +1,4 @@
+{
+  "name": "Nuevo Proyecto",
+  "tasks": []
+}

--- a/templates/taskTemplate.json
+++ b/templates/taskTemplate.json
@@ -1,0 +1,8 @@
+{
+  "title": "Nueva Tarea",
+  "description": "Descripcion",
+  "status": "To Do",
+  "priority": "Media",
+  "type": "General",
+  "estimate": 1
+}


### PR DESCRIPTION
## Summary
- make task rows and kanban cards draggable
- add handlers to drop tasks in kanban columns and reorder list items
- track the dragged task to update project data
- clear drag state on drag end

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6851f6cb6a8c832594648dd9950550ae