### PR TITLE
Implement VS Code themed style

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,6 @@ Divnex es una WebApp local para gestión de proyectos inspirada en ClickUp y Mon
 - Las tareas con fecha se muestran en el calendario de forma automática.
 
 La aplicación incluye datos de ejemplo la primera vez que se abre para mostrar el funcionamiento básico.
+## Temas
+
+Puedes cambiar entre el tema claro y uno inspirado en VS Code desde el menú superior. El ajuste se guarda en `localStorage`.

--- a/components/kanban.js
+++ b/components/kanban.js
@@ -11,7 +11,7 @@ export function statusColor(status) {
 
 export function createKanbanColumn(title) {
   const column = document.createElement('div');
-  column.className = 'kanban-column bg-gray-100 rounded-lg p-4 flex-1 mr-4 last:mr-0';
+  column.className = 'kanban-column flex-1 mr-4 last:mr-0';
   const header = document.createElement('h3');
   header.className = 'font-semibold mb-2';
   header.textContent = title;
@@ -24,7 +24,7 @@ export function createKanbanColumn(title) {
 
 export function createTaskCard(task, handlers = {}) {
   const card = document.createElement('div');
-  card.className = 'relative bg-white rounded-lg shadow p-4 text-sm cursor-pointer select-none min-h-[96px] flex flex-col justify-between';
+  card.className = 'task-card relative text-sm cursor-pointer select-none min-h-[96px] flex flex-col justify-between';
   card.draggable = true;
   card.dataset.id = task.id;
   card.style.borderLeft = `4px solid ${task.color || statusColor(task.status)}`;

--- a/index.html
+++ b/index.html
@@ -16,8 +16,9 @@
     };
   </script>
   <link rel="stylesheet" href="styles/main.css">
+  <link id="themeStylesheet" rel="stylesheet" href="styles/theme-vscode.css" disabled>
 </head>
-<body class="font-inter bg-gray-50 h-screen flex flex-col">
+<body class="font-inter h-screen flex flex-col">
   <header class="bg-gradient-to-r from-indigo-500 to-blue-500 text-white p-4 flex justify-between items-center">
     <h1 class="text-xl font-semibold">Divnex</h1>
     <nav class="space-x-2">
@@ -28,6 +29,10 @@
       <button id="importBtn" class="px-3 py-1 rounded-md bg-white/20 hover:bg-white/30">Importar</button>
       <button id="addTaskBtn" class="ml-3 px-3 py-1 rounded-md bg-white/20 hover:bg-white/30">Nueva Tarea</button>
       <input type="file" id="importFile" class="hidden" />
+      <select id="themeSelect" class="ml-3 px-2 py-1 rounded-md bg-white/20 text-white">
+        <option value="light">Claro</option>
+        <option value="vscode">VS Code</option>
+      </select>
     </nav>
   </header>
   <div id="container" class="flex flex-1 overflow-hidden">
@@ -91,5 +96,17 @@
   </div>
   <script type="module" src="divnex.js"></script>
   <script type="module" src="debug_test.js"></script>
+  <script>
+    const themeLink = document.getElementById('themeStylesheet');
+    const themeSelect = document.getElementById('themeSelect');
+    const savedTheme = localStorage.getItem('theme') || 'light';
+    themeSelect.value = savedTheme;
+    if (savedTheme === 'vscode') themeLink.disabled = false;
+    themeSelect.addEventListener('change', () => {
+      const val = themeSelect.value;
+      localStorage.setItem('theme', val);
+      themeLink.disabled = val !== 'vscode';
+    });
+  </script>
 </body>
 </html>

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,7 +1,18 @@
+:root {
+  --bg: #f9fafb;
+  --fg: #111827;
+  --accent: #6366f1;
+  --accent-bg: rgba(99,102,241,0.2);
+  --card-bg: #ffffff;
+  --border-color: #e5e7eb;
+}
+
 body {
   margin: 0;
-  font-family: 'Inter', sans-serif;
-  background: #f9fafb;
+  font-family: 'Inter', 'Segoe UI', 'Fira Code', sans-serif;
+  background: var(--bg);
+  color: var(--fg);
+  transition: background 0.3s, color 0.3s;
 }
 
 .select-none {
@@ -13,9 +24,27 @@ body {
 }
 
 .highlight-drop-target {
-  background-color: rgba(59, 130, 246, 0.2);
-  border: 2px dashed #3b82f6;
-  transition: all 0.2s ease;
+  background-color: var(--accent-bg);
+  border: 2px dashed var(--accent);
+  transition: background-color 0.2s, border-color 0.2s;
+}
+
+.task-card {
+  background: var(--card-bg);
+  border-radius: 12px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  padding: 16px;
+  color: var(--fg);
+  transition: box-shadow 0.2s, background 0.2s;
+}
+.task-card:hover {
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+}
+
+.kanban-column {
+  background: var(--card-bg);
+  border-radius: 12px;
+  padding: 16px;
 }
 
 .bg-indigo-100 {

--- a/styles/theme-vscode.css
+++ b/styles/theme-vscode.css
@@ -1,0 +1,8 @@
+:root {
+  --bg: #1e1e1e;
+  --fg: #d4d4d4;
+  --accent: #569cd6;
+  --accent-bg: rgba(86, 156, 214, 0.3);
+  --card-bg: rgba(37, 37, 38, 0.9);
+  --border-color: #3c3c3c;
+}


### PR DESCRIPTION
## Summary
- create `theme-vscode.css` with Dark+ palette
- redesign Kanban cards with `.task-card` class
- add theme selector to `index.html`
- wire up theme toggle logic
- document theme switcher in README

## Testing
- `node debug_test.js` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6852c8b22ff08325bab46cbbb6331bc5