### PR TITLE
Improve header image input in task modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,11 +49,14 @@
   </div>
   <div id="taskModal" class="modal hidden">
     <div class="modal-content bg-white dark:bg-gray-800">
-      <div id="headerPreview" class="h-24 rounded-t-2xl bg-gray-200 dark:bg-gray-700 bg-cover bg-center relative">
+      <div id="headerPreview" class="relative h-24 rounded-t-2xl bg-gray-200 dark:bg-gray-700 bg-cover bg-center overflow-hidden">
         <input id="headerColor" type="color" class="absolute bottom-2 left-2 color-input" />
-        <input id="headerImage" type="file" accept="image/*" class="absolute bottom-2 left-20 file-input w-auto" />
+        <label for="headerImage" class="absolute bottom-2 left-20 bg-white text-gray-800 px-3 py-1 rounded shadow hover:bg-gray-100 cursor-pointer">
+          Cambiar Imagen
+        </label>
+        <input id="headerImage" type="file" accept="image/*" class="hidden" />
       </div>
-      <div class="p-6 grid grid-cols-2 gap-6">
+      <div class="px-6 pb-6 pt-4 grid grid-cols-2 gap-6">
         <div class="flex-1 space-y-3">
           <h3 id="taskModalTitle" class="text-lg font-semibold">Nueva Tarea</h3>
           <input id="taskTitle" type="text" class="input-group" placeholder="Título" />


### PR DESCRIPTION
## Summary
- modernize the header image controls on the task modal
- reduce spacing below the header image

## Testing
- `node debug_test.js` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6852dd2d67e4832589e7ad3a54ce85ba